### PR TITLE
fix: Allow standard Kubernetes metadata fields in K8sDenyDelete schema [No Jira]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # kubernetes-json-schema
 
 use https://github.com/datreeio/CRDs-catalog#crd-extractor to extract schemas
+
+The tool would extract schema for all the CRDs. 
+
+To extract singular schema against cluster claude can be used.

--- a/schemas/k8sdenydelete_v1beta1.json
+++ b/schemas/k8sdenydelete_v1beta1.json
@@ -5,6 +5,21 @@
         "name": {
           "maxLength": 63,
           "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "type": "object",


### PR DESCRIPTION
The K8sDenyDelete constraint schema was too restrictive, only allowing 'name' in metadata. This caused validation errors when ArgoCD added annotations (argocd.argoproj.io/tracking-id) during resource sync.

Changes:
- Added 'namespace' field support
- Added 'labels' object support
- Added 'annotations' object support

These are standard Kubernetes metadata fields that should be allowed on all resources. ArgoCD and other controllers commonly add annotations for tracking and management purposes.

Fixes validation errors:
- deny-rds-delete: additionalProperties 'namespace', 'annotations' not allowed
- deny-redis-delete: additionalProperties 'annotations', 'namespace' not allowed
- deny-s3-bucket-delete: additionalProperties 'namespace', 'annotations' not allowed