### PR TITLE
Fix MWAA Environment tags schema to match actual CRD

### DIFF
--- a/schemas/environment_v1alpha1.json
+++ b/schemas/environment_v1alpha1.json
@@ -603,20 +603,11 @@
               "type": "string"
             },
             "tags": {
-              "description": "The key-value tag pairs you want to associate to your environment. Tags should be provided as an array of objects with 'key' and 'value' properties. For more information, see Tagging Amazon Web Services resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html).",
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": ["key", "value"],
-                "properties": {
-                  "key": {
-                    "type": "string"
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The key-value tag pairs you want to associate to your environment. For example, \"Environment\": \"Staging\". For more information, see Tagging Amazon Web Services resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html).",
+              "type": "object"
             },
             "webserverAccessMode": {
               "description": "The Apache Airflow Web server access mode. For more information, see Apache Airflow access modes (https://docs.aws.amazon.com/mwaa/latest/userguide/configuring-networking.html).",


### PR DESCRIPTION
## Summary
Fixes the MWAA Environment tags schema to match the actual Crossplane CRD specification from provider-aws v0.53.0.

## Problem
The current schema defines `tags` as an array of objects with `key` and `value` properties, but the actual Crossplane MWAA Environment CRD defines tags as an object with string properties (using `additionalProperties`).

This mismatch causes kubeconform validation failures:
```
jsonschema: '/spec/forProvider/tags' does not validate: expected array, but got object
```

## Changes
**Before (incorrect):**
```json
"tags": {
  "type": "array",
  "items": {
    "type": "object",
    "required": ["key", "value"],
    "properties": {
      "key": {"type": "string"},
      "value": {"type": "string"}
    }
  }
}
```

**After (correct):**
```json
"tags": {
  "type": "object",
  "additionalProperties": {
    "type": "string"
  }
}
```

## Validation
This matches the actual CRD from the cluster:
```bash
kubectl get crd environments.mwaa.aws.crossplane.io -o yaml
```

Shows:
```yaml
tags:
  additionalProperties:
    type: string
  description: "The key-value tag pairs..."
  type: object
```

## Impact
- ✅ Allows proper validation of MWAA Environment resources
- ✅ Matches actual Kubernetes CRD specification
- ✅ Enables correct tag format: `{"Owner": "GDC", "Environment": "production"}`

## Related
- Configuration PR: g2crowd/configuration#2384

🤖 Generated with [Claude Code](https://claude.com/claude-code)