### PR TITLE
fix: revert IAM and EC2 tags to array format to match cluster CRDs NO-JIRA

### DIFF
--- a/schemas/policy_v1beta1.json
+++ b/schemas/policy_v1beta1.json
@@ -44,11 +44,23 @@
               "type": "string"
             },
             "tags": {
-              "additionalProperties": {
-                "type": "string"
-              },
               "description": "Tags. For more information about tagging, see Tagging IAM Identities (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User Guide.",
-              "type": "object"
+              "items": {
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "type": "array"
             }
           },
           "required": [

--- a/schemas/role_v1beta1.json
+++ b/schemas/role_v1beta1.json
@@ -49,11 +49,23 @@
               "type": "string"
             },
             "tags": {
-              "additionalProperties": {
-                "type": "string"
-              },
               "description": "Tags. For more information about tagging, see Tagging IAM Identities (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User Guide.",
-              "type": "object"
+              "items": {
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "type": "array"
             }
           },
           "required": [

--- a/schemas/securitygroup_v1beta1.json
+++ b/schemas/securitygroup_v1beta1.json
@@ -626,11 +626,23 @@
               "type": "string"
             },
             "tags": {
-              "additionalProperties": {
-                "type": "string"
-              },
               "description": "Tags represents to current ec2 tags.",
-              "type": "object"
+              "items": {
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "type": "array"
             },
             "vpcId": {
               "description": "VPCID is the ID of the VPC.",


### PR DESCRIPTION
## Summary
Reverts tags schema from object to array format for IAM Role, IAM Policy, and EC2 SecurityGroup to match the actual Crossplane CRD schemas in the cluster.

## Problem
PR #2385 incorrectly changed these schemas to object format based on kubeconform warnings, but the **actual CRDs in the cluster expect array format**, causing validation warnings in kubechecks.

## Root Cause
The kubeconform warnings "expected object, but got array" were misleading. The actual Kubernetes cluster CRDs require array format for tags.

## Verification
Checked actual CRD in cluster:
```bash
kubectl get crd roles.iam.aws.crossplane.io -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.forProvider.properties.tags.type}'
# Output: array
```

## Changes
- `schemas/role_v1beta1.json`: tags type object → array with key/value items
- `schemas/policy_v1beta1.json`: tags type object → array with key/value items
- `schemas/securitygroup_v1beta1.json`: tags type object → array with key/value items

## Schema Format
```json
"tags": {
  "type": "array",
  "items": {
    "type": "object",
    "properties": {
      "key": {"type": "string"},
      "value": {"type": "string"}
    },
    "required": ["key", "value"]
  }
}
```

## Manifest Format (matches cluster CRDs)
```yaml
tags:
- key: Owner
  value: GDC
- key: Production
  value: "false"
```

## Impact
- Fixes kubeconform validation warnings for airflow applications
- Schemas now match actual cluster CRD expectations
- Related to configuration PR #2386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>