### PR TITLE
fix: revert RDS tags to array format to match cluster CRDs NO-JIRA

### DIFF
--- a/schemas/dbsubnetgroup_v1beta1.json
+++ b/schemas/dbsubnetgroup_v1beta1.json
@@ -127,11 +127,23 @@
               "type": "array"
             },
             "tags": {
-              "additionalProperties": {
-                "type": "string"
-              },
               "description": "A list of tags. For more information, see Tagging Amazon RDS Resources (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html) in the Amazon RDS User Guide.",
-              "type": "object"
+              "items": {
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "type": "array"
             }
           },
           "required": [

--- a/schemas/rdsinstance_v1beta1.json
+++ b/schemas/rdsinstance_v1beta1.json
@@ -801,11 +801,23 @@
               "type": "string"
             },
             "tags": {
-              "additionalProperties": {
-                "type": "string"
-              },
               "description": "Tags. For more information, see Tagging Amazon RDS Resources (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html) in the Amazon RDS User Guide.",
-              "type": "object"
+              "items": {
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "type": "array"
             },
             "timezone": {
               "description": "Timezone of the DB instance. The time zone parameter is currently supported only by Microsoft SQL Server (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html#SQLServer.Concepts.General.TimeZone).",


### PR DESCRIPTION
## Summary
Reverts tags schema from object to array format for RDS resources (DBSubnetGroup and RDSInstance) to match the actual Crossplane CRD schemas in the cluster.

## Problem
Kubeconform validation warnings for data-pipelines applications:
```
⚠️ Invalid: database.aws.crossplane.io/v1beta1 DBSubnetGroup data-pipelines-postgresql-sng
jsonschema: '/spec/forProvider/tags' does not validate: expected object, but got array

⚠️ Invalid: database.aws.crossplane.io/v1beta1 RDSInstance data-pipelines-rds
jsonschema: '/spec/forProvider/tags' does not validate: expected object, but got array
```

## Root Cause
The RDS schemas were still in object format after PR #6 fixed IAM and EC2 schemas. The actual CRDs in the cluster expect array format.

## Verification Against Cluster CRDs
Validated tags type in both development and production clusters:

```bash
kubectl get crd dbsubnetgroups.database.aws.crossplane.io -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.forProvider.properties.tags.type}'
# Output: array

kubectl get crd rdsinstances.database.aws.crossplane.io -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.forProvider.properties.tags.type}'
# Output: array
```

## Changes
- `schemas/dbsubnetgroup_v1beta1.json`: tags type object → array with key/value items
- `schemas/rdsinstance_v1beta1.json`: tags type object → array with key/value items

## Schema Format
```json
"tags": {
  "type": "array",
  "items": {
    "type": "object",
    "properties": {
      "key": {"type": "string"},
      "value": {"type": "string"}
    },
    "required": ["key", "value"]
  }
}
```

## Manifest Format (matches cluster CRDs)
```yaml
tags:
- key: Owner
  value: GDC
- key: Production
  value: "false"
```

## Impact
- Fixes kubeconform validation warnings for data-pipelines-development
- Fixes kubeconform validation warnings for data-pipelines-production
- Schemas now match actual cluster CRD expectations
- Completes the schema fixes started in PR #6

## Related
- PR #6: Fixed IAM and EC2 schemas (already merged)
- configuration PR #2387: Fixes data-pipelines manifests to use array format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>