### PR TITLE
fix: Make namespace optional in writeConnectionSecretToRef for Upbound Cluster v1beta1

### DIFF
--- a/schemas/cluster_v1beta1.json
+++ b/schemas/cluster_v1beta1.json
@@ -1136,13 +1136,12 @@
               "type": "string"
             },
             "namespace": {
-              "description": "Namespace of the secret.",
+              "description": "Namespace of the secret. Optional for Upbound managed resources where namespace is inherited from metadata.namespace.",
               "type": "string"
             }
           },
           "required": [
-            "name",
-            "namespace"
+            "name"
           ],
           "type": "object",
           "additionalProperties": false


### PR DESCRIPTION
## Problem
Upbound AWS provider v2.x managed resources (`elasticache.aws.m.upbound.io`) **do NOT support** the `namespace` field in `writeConnectionSecretToRef`. The secret namespace is automatically determined from the resource's `metadata.namespace` field.

However, the current JSON schema validation requires both `name` and `namespace` fields in the `writeConnectionSecretToRef` block, causing CI/CD failures when deploying Upbound Cluster resources.

**Error from CI/CD validation**:
```
⚠️ Invalid: elasticache.aws.m.upbound.io/v1beta1 Cluster tracking-api-cache-upbound
problem validating schema. Check JSON formatting: jsonschema: '/spec/writeConnectionSecretToRef' 
does not validate with https://raw.githubusercontent.com/g2crowd/kubernetes-json-schema/refs/heads/main/schemas/cluster_v1beta1.json#/properties/spec/properties/writeConnectionSecretToRef/required: 
missing properties: 'namespace'
```

## Root Cause
API differences between provider types:
- **crossplane-contrib provider** (`cache.aws.crossplane.io`): Requires explicit `namespace` field
- **Upbound provider** (`elasticache.aws.m.upbound.io`): Does NOT support `namespace` field (errors if present)

This creates a conflict where:
- Runtime: Upbound provider rejects `namespace` field
- CI/CD: Schema validation requires `namespace` field

## Solution
Make the `namespace` field **optional** by removing it from the `required` array in the `writeConnectionSecretToRef` schema definition.

**Before**:
```json
"required": [
  "name",
  "namespace"
]
```

**After**:
```json
"required": [
  "name"
]
```

Also updated the description of the `namespace` field to clarify it's optional for Upbound managed resources.

## Benefits
✅ Fixes CI/CD validation errors for Upbound Cluster resources  
✅ Enables PE-418 migration from crossplane-contrib to Upbound providers  
✅ Maintains backward compatibility - crossplane-contrib resources can still provide namespace  
✅ Aligns schema with Upbound provider runtime behavior  
✅ Fixes this for all future Upbound Cluster resources (not just PE-418)

## Testing
After merge:
1. This PR will unblock configuration repo PR #2409 from passing CI/CD checks
2. Upbound Cluster resources without `namespace` field will pass validation
3. Resources with `namespace` field will still pass (backward compatible)

## Impact
- **No breaking changes**: Resources can still provide `namespace` if needed
- **Fixes**: All Upbound Cluster v1beta1 resources across all environments
- **Enables**: Migration from crossplane-contrib provider to Upbound provider

## Related
- **Jira**: [PE-418](https://g2crowd.atlassian.net/browse/PE-418) - ElastiCache infinite reconciliation migration
- **Blocked PR**: configuration#2409 (waiting on this schema fix)
- **Provider Documentation**: [Upbound Provider AWS](https://marketplace.upbound.io/providers/upbound/provider-family-aws)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PE-418]: https://g2crowd.atlassian.net/browse/PE-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ