### PR TITLE
fix: Add kind field to SubnetGroup providerConfigRef schema [G2DEVOPS-743]

### DIFF
--- a/schemas/subnetgroup_v1beta1.json
+++ b/schemas/subnetgroup_v1beta1.json
@@ -277,6 +277,10 @@
           },
           "description": "ProviderConfigReference specifies how the provider that will be used to\ncreate, observe, update, and delete this managed resource should be\nconfigured.",
           "properties": {
+            "kind": {
+              "description": "Kind of the referenced object.",
+              "type": "string"
+            },
             "name": {
               "description": "Name of the referenced object.",
               "type": "string"


### PR DESCRIPTION
## Summary
This PR fixes the SubnetGroup JSON schema to match the actual Upbound CRD specification.

## Problem
The `providerConfigRef` schema for SubnetGroup was missing the `kind` field, causing validation errors like:
```
⚠️ Invalid: elasticache.aws.m.upbound.io/v1beta1 SubnetGroup
additionalProperties 'kind' not allowed
```

## Root Cause
The schema only allowed `name` and `policy` fields in `providerConfigRef`, but the actual Upbound CRD requires:
- **kind** (string): Kind of the referenced object
- **name** (string): Name of the referenced object  
- **policy** (object, optional): Referencing policies

## Changes
Added the `kind` property to the `providerConfigRef.properties` section in:
- `schemas/subnetgroup_v1beta1.json`

## Validation
- ✓ JSON syntax validated
- ✓ Matches Upbound official schema at https://marketplace.upbound.io/providers/upbound/provider-aws-elasticache/v2.3.0/resources/elasticache.aws.m.upbound.io/SubnetGroup/v1beta1

## Related Issues
- Jira: [G2DEVOPS-743](https://g2crowd.atlassian.net/browse/G2DEVOPS-743)
- Blocks: https://github.com/g2crowd/configuration/pull/2859

## Testing
After this PR is merged, the companies-service Valkey cache PR should pass validation checks.

[G2DEVOPS-743]: https://g2crowd.atlassian.net/browse/G2DEVOPS-743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ