### PR TITLE
fix: add missing 'kind' field to ReplicationGroup providerConfigRef schema [G2DEVOPS-743]

### DIFF
--- a/schemas/replicationgroup_v1beta1.json
+++ b/schemas/replicationgroup_v1beta1.json
@@ -995,6 +995,10 @@
           },
           "description": "ProviderConfigReference specifies how the provider that will be used to\ncreate, observe, update, and delete this managed resource should be\nconfigured.",
           "properties": {
+            "kind": {
+              "description": "Kind of the referenced object.",
+              "type": "string"
+            },
             "name": {
               "description": "Name of the referenced object.",
               "type": "string"


### PR DESCRIPTION
## Summary
Adds the missing `kind` field to the `providerConfigRef` properties in ReplicationGroup v1beta1 schema.

## Problem
The Upbound provider-aws-elasticache ReplicationGroup resource validation fails with:
```
additionalProperties 'kind' not allowed in providerConfigRef
```

## Root Cause
The JSON schema for ReplicationGroup v1beta1 was missing the `kind` property in `providerConfigRef`, even though Crossplane's providerConfigRef requires it.

## Changes Made
Added `kind` field to `/schemas/replicationgroup_v1beta1.json`:
```json
"providerConfigRef": {
  "properties": {
    "kind": {
      "description": "Kind of the referenced object.",
      "type": "string"
    },
    "name": { ... },
    "policy": { ... }
  }
}
```

## Related
- Same issue fixed for SubnetGroup in PR #14
- Jira: G2DEVOPS-743 (Valkey cache deployment)
- Blocks: g2crowd/configuration PR #2864