### PR TITLE
fix: make writeConnectionSecretToRef.namespace optional for ReplicationGroup [G2DEVOPS-743]

### DIFF
--- a/schemas/replicationgroup_v1beta1.json
+++ b/schemas/replicationgroup_v1beta1.json
@@ -259,7 +259,7 @@
               "type": "string"
             },
             "port": {
-              "description": "\u2013  Port number on which each of the cache nodes will accept connections. For Memcache the default is 11211, and for Redis the default port is 6379.",
+              "description": "–  Port number on which each of the cache nodes will accept connections. For Memcache the default is 11211, and for Redis the default port is 6379.",
               "type": "number"
             },
             "preferredCacheClusterAzs": {
@@ -382,7 +382,7 @@
               "x-kubernetes-list-type": "set"
             },
             "snapshotArns": {
-              "description": "\u2013  List of ARNs that identify Redis RDB snapshot files stored in Amazon S3. The names object names cannot contain any commas.",
+              "description": "–  List of ARNs that identify Redis RDB snapshot files stored in Amazon S3. The names object names cannot contain any commas.",
               "items": {
                 "type": "string"
               },
@@ -724,7 +724,7 @@
               "type": "string"
             },
             "port": {
-              "description": "\u2013  Port number on which each of the cache nodes will accept connections. For Memcache the default is 11211, and for Redis the default port is 6379.",
+              "description": "–  Port number on which each of the cache nodes will accept connections. For Memcache the default is 11211, and for Redis the default port is 6379.",
               "type": "number"
             },
             "preferredCacheClusterAzs": {
@@ -843,7 +843,7 @@
               "x-kubernetes-list-type": "set"
             },
             "snapshotArns": {
-              "description": "\u2013  List of ARNs that identify Redis RDB snapshot files stored in Amazon S3. The names object names cannot contain any commas.",
+              "description": "–  List of ARNs that identify Redis RDB snapshot files stored in Amazon S3. The names object names cannot contain any commas.",
               "items": {
                 "type": "string"
               },
@@ -1123,8 +1123,7 @@
             }
           },
           "required": [
-            "name",
-            "namespace"
+            "name"
           ],
           "type": "object",
           "additionalProperties": false
@@ -1298,7 +1297,7 @@
               "type": "string"
             },
             "port": {
-              "description": "\u2013  Port number on which each of the cache nodes will accept connections. For Memcache the default is 11211, and for Redis the default port is 6379.",
+              "description": "–  Port number on which each of the cache nodes will accept connections. For Memcache the default is 11211, and for Redis the default port is 6379.",
               "type": "number"
             },
             "preferredCacheClusterAzs": {
@@ -1341,7 +1340,7 @@
               "x-kubernetes-list-type": "set"
             },
             "snapshotArns": {
-              "description": "\u2013  List of ARNs that identify Redis RDB snapshot files stored in Amazon S3. The names object names cannot contain any commas.",
+              "description": "–  List of ARNs that identify Redis RDB snapshot files stored in Amazon S3. The names object names cannot contain any commas.",
               "items": {
                 "type": "string"
               },


### PR DESCRIPTION
## Summary
Makes the `namespace` field optional (not required) in `writeConnectionSecretToRef` for ReplicationGroup resources.

## Problem
The current schema incorrectly requires both `name` and `namespace` fields:
```json
"required": ["name", "namespace"]
```

This is inconsistent with:
- How ElastiCache **Cluster** resources work (namespace is optional)
- Kubernetes/Kustomize patterns where namespace is inferred from the kustomization namespace setting
- All existing ElastiCache resources in the codebase which don't specify namespace

## Solution
Changed to make only `name` required:
```json
"required": ["name"]
```

The `namespace` field remains available for explicit specification when needed, but can now be omitted to allow inference from kustomization context.

## Impact
- Fixes validation errors for ReplicationGroup resources that follow the standard pattern
- Brings ReplicationGroup in line with Cluster resource behavior
- Allows companies-service Valkey deployment to proceed without schema validation errors

## Related
- G2DEVOPS-743: Companies service Redis upgrade to Valkey 7.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)