### PR TITLE
fix: allow null syncPolicy in Application schema NO-JIRA

### DIFF
--- a/schemas/application_v1alpha1.json
+++ b/schemas/application_v1alpha1.json
@@ -2220,7 +2220,7 @@
               "type": "array"
             }
           },
-          "type": "object",
+          "type": ["object", "null"],
           "additionalProperties": false
         }
       },


### PR DESCRIPTION
## Summary

- Allow `spec.syncPolicy` to be `null` in the ArgoCD Application schema by changing the type from `"object"` to `["object", "null"]`

## Problem

ArgoCD Applications with `syncPolicy:` set but all children commented out (e.g., for manual sync in dev environments) parse as `syncPolicy: null` in YAML. The current schema rejects this with:

```
expected object, but got null
```

This blocks validation for [g2crowd/configuration#3251](https://github.com/g2crowd/configuration/pull/3251) (`ai-playbooks-development`), which intentionally disables automated sync for fast dev iteration via `kubectl apply`.

## Fix

Changed `spec.syncPolicy.type` from `"object"` to `["object", "null"]`. This is correct per ArgoCD's actual behavior — a null syncPolicy means manual sync only.

## Validation

Tested with `kubeconform` against:
- ✅ `ai-playbooks-development` (null syncPolicy) — now passes
- ✅ `ai-playbooks-production` (full syncPolicy object) — still passes
- ✅ `next-js-starter-development` (existing app, full syncPolicy) — still passes