### PR TITLE
fix: update SecurityGroup v1beta1 tags schema from array to object

### DIFF
--- a/schemas/securitygroup_v1beta1.json
+++ b/schemas/securitygroup_v1beta1.json
@@ -626,23 +626,11 @@
               "type": "string"
             },
             "tags": {
-              "description": "Tags represents to current ec2 tags.",
-              "items": {
-                "properties": {
-                  "key": {
-                    "type": "string"
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "key",
-                  "value"
-                ],
-                "type": "object"
+              "additionalProperties": {
+                "type": "string"
               },
-              "type": "array"
+              "description": "Key-value map of resource tags.",
+              "type": "object"
             },
             "vpcId": {
               "description": "VPCID is the ID of the VPC.",


### PR DESCRIPTION
## Summary

- Fix `spec.forProvider.tags` type in `securitygroup_v1beta1.json` from `array` (of `{key, value}` objects) to `object` (string-to-string map with `additionalProperties`)

## Reason

The JSON schema was generated from the older crossplane-contrib AWS provider which used array-style tags. The current Upbound provider (`ec2.aws.upbound.io/v1beta1`) installed on the tools cluster defines tags as a key-value map:

```json
// CRD on cluster (correct):
"tags": {
  "additionalProperties": { "type": "string" },
  "description": "Key-value map of resource tags.",
  "type": "object"
}

// Old schema (incorrect):
"tags": {
  "items": { "properties": { "key": {...}, "value": {...} } },
  "type": "array"
}
```

This was causing false positive validation warnings on PRs in `g2crowd/configuration` that use SecurityGroup resources (e.g., `litellm-redis-sg`).

## Verification

Confirmed against the live CRD on the tools cluster:
```
kubectl get crd securitygroups.ec2.aws.upbound.io -o jsonpath='{.spec.versions[?(@.name==\"v1beta1\")].schema.openAPIV3Schema.properties.spec.properties.forProvider.properties.tags}'
```
Returns `{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Key-value map of resource tags.\",\"type\":\"object\"}`