### PR TITLE
fix(securitygroup): [PE-804] add kind to providerConfigRef schema

### DIFF
--- a/schemas/securitygroup_v1beta1.json
+++ b/schemas/securitygroup_v1beta1.json
@@ -772,6 +772,10 @@
               },
               "type": "object",
               "additionalProperties": false
+            },
+            "kind": {
+              "description": "Kind of the referenced object.",
+              "type": "string"
             }
           },
           "required": [


### PR DESCRIPTION
## Summary
- Adds optional `kind` field to `providerConfigRef` in `securitygroup_v1beta1.json` schema
- Required by `upbound.m` (managed services) provider which sets `kind: ProviderConfig` in `providerConfigRef`
- Non-breaking: `kind` is optional so existing resources without it continue to pass validation

## Test plan
- [ ] Verify `kubeconform` no longer warns on SecurityGroup resources with `providerConfigRef.kind`
- [ ] Verify existing SecurityGroup resources without `kind` still pass validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)